### PR TITLE
fix the `trigger` function of local hot reload, which must return the promise object

### DIFF
--- a/generators/hotreload/hotreload/LocalHotReload.js
+++ b/generators/hotreload/hotreload/LocalHotReload.js
@@ -17,6 +17,6 @@ module.exports = {
 
     this.log.writeln();
     this.log.info('Writing changes on `dev.bundles` file:');
-    this.fs.write(this._getDevBuildsPath(), content);
+    return this.fs.write(this._getDevBuildsPath(), content);
   }
 };


### PR DESCRIPTION
If I use the local hot reload, then the build process ended with the error
```
(node:90972) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'then' of undefined
    at constructor.writing (/usr/lib/node_modules/nuxeo-cli/node_modules/generator-nuxeo/generators/hotreload/hotreload-delegate.js:86:20)
    at delegate (/usr/lib/node_modules/nuxeo-cli/node_modules/generator-nuxeo/lib/delegated-generator.js:92:31)
    at constructor.writing (/usr/lib/node_modules/nuxeo-cli/node_modules/generator-nuxeo/lib/delegated-generator.js:73:7)
    at Object.<anonymous> (/usr/lib/node_modules/nuxeo-cli/node_modules/generator-nuxeo/node_modules/yeoman-generator/lib/index.js:417:23)
    at /usr/lib/node_modules/nuxeo-cli/node_modules/generator-nuxeo/node_modules/run-async/index.js:49:25
    at new Promise (<anonymous>)
    at /usr/lib/node_modules/nuxeo-cli/node_modules/generator-nuxeo/node_modules/run-async/index.js:26:19
    at /usr/lib/node_modules/nuxeo-cli/node_modules/generator-nuxeo/node_modules/yeoman-generator/lib/index.js:418:9
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
(node:90972) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:90972) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
The reason for this behavior is the missed `return` statement in the `trigger` function. A `Promise` is expected when calling this function, but nothing (`undefined`) is returned instead.

This PR fix the problem.